### PR TITLE
feat: RPC 毎に許可するロールを定義する

### DIFF
--- a/grpc-server-with-envoy/opa/authz.rego
+++ b/grpc-server-with-envoy/opa/authz.rego
@@ -25,17 +25,14 @@ no_authz_rpc if {
 }
 
 is_allowed_permission contains role if {
-	role_permission := {
-		"admin": [
-			{"service": "misc.v1.MiscService", "rpc": "Create"},
-			{"service": "misc.v1.MiscService", "rpc": "List"},
-		],
-		"guest": [{"service": "misc.v1.MiscService", "rpc": "List"}],
-	}
+	rpc_permission := {"misc.v1.MiscService": [
+		{"rpc": "Create", "roles": ["admin"]},
+		{"rpc": "List", "roles": ["admin", "guest"]},
+	]}
 
-	some p in role_permission[role]
-	parsed_path[0] == p.service
+	some p in rpc_permission[parsed_path[0]]
 	parsed_path[1] == p.rpc
+	some _, role in p.roles
 }
 
 token := {"payload": payload} if {


### PR DESCRIPTION
# Overview

ロール毎に許可する RPC を設定していたが、同一 RPC で複数のロールを持つ場合に同じ RPC を2度書かなくてはならなかった
そこで、RPC 毎に許可するロールを定義する形に変更する

https://github.com/pyama2000/demo-open-policy-agent/blob/e4c838cc669e1c7bdf26810fdc12379806cfb9be/grpc-server-with-envoy/opa/authz.rego#L28-L34
